### PR TITLE
Better APPX error message.

### DIFF
--- a/AzureSignTool/Program.cs
+++ b/AzureSignTool/Program.cs
@@ -76,6 +76,12 @@ namespace AzureSignTool
                         }
                         else
                         {
+                            switch (result)
+                            {
+                                case unchecked((int)0x8007000B):
+                                    Console.WriteLine("The Publisher Identity in the AppxManifest.xml does not match the subject on the certificate.");
+                                    break;
+                            }
                             Console.WriteLine($"Signing failed with error {result:X2}.");
                         }
                         return result;


### PR DESCRIPTION
The subject in the APPX must match the signing certificate. This prints a helpful error message if that appears to be the case.

I'm not real in to the idea of trying to figure out what the expected Subject should be. Unzipping a file and reading an XML file is considerable for this.

Fixes #5.