### PR TITLE
Update project to build as a .NET Core 2.1 console tool package 

### DIFF
--- a/AzureSignTool.Tests/AzureSignTool.Tests.csproj
+++ b/AzureSignTool.Tests/AzureSignTool.Tests.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net471</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <PlatformTarget>anycpu</PlatformTarget>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/AzureSignTool/AzureSignTool.csproj
+++ b/AzureSignTool/AzureSignTool.csproj
@@ -1,21 +1,26 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net471</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <PlatformTarget>anycpu</PlatformTarget>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Kevin Jones</Authors>
-    <Description>Azure SignTool</Description>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>AzureSignTool.snk</AssemblyOriginatorKeyFile>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>azuresigntool</ToolCommandName>
+    <Description>Azure Sign Tool is similar to signtool in the Windows SDK, with the major difference being that it uses Azure Key Vault for performing the signing process. The usage is like signtool, except with a limited set of options for signing and options for authenticating to Azure Key Vault.</Description>
+    <PackageProjectUrl>https://github.com/vcsjones/AzureSignTool</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/vcsjones/AzureSignTool</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>azuresigntool;azure;keyvault;codesign</PackageTags>
   </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.17.2" />
-    <PackageReference Include="Microsoft.Azure.KeyVault" Version="2.3.2" />
-    <PackageReference Include="Microsoft.Azure.KeyVault.Cryptography" Version="2.0.5" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.8" />
+    <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Azure.KeyVault.Cryptography" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/AzureSignTool/HRESULT.cs
+++ b/AzureSignTool/HRESULT.cs
@@ -6,6 +6,7 @@
         public const int E_INVALIDARG = unchecked((int)0x80070057);
         public const int COR_E_BADIMAGEFORMAT = unchecked((int)0x8007000B);
         public const int E_FILE_NOT_FOUND = unchecked((int)0x80070002);
+        public const int E_PLATFORMNOTSUPPORTED = unchecked((int)0x80131539);
 
         public const int S_SOME_SUCCESS = 0x20000001;
         public const int E_ALL_FAILED = unchecked((int)0xA0000002);

--- a/AzureSignTool/Program.cs
+++ b/AzureSignTool/Program.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -15,8 +16,19 @@ namespace AzureSignTool
     {
         static int Main(string[] args)
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Console.Error.WriteLine("Azure Sign Tool is only supported on Windows.");
+                return E_PLATFORMNOTSUPPORTED;
+            }
+
             LoggerServiceLocator.Current = new ConsoleLogger();
-            var application = new CommandLineApplication(throwOnUnexpectedArg: false);
+            var application = new CommandLineApplication(throwOnUnexpectedArg: false)
+            {
+                Name = "azuresigntool",
+                FullName = "Azure Sign Tool",
+            };
+
             var signCommand = application.Command("sign", throwOnUnexpectedArg: false, configuration: cfg =>
             {
                 cfg.Description = "Signs a file.";
@@ -251,6 +263,11 @@ namespace AzureSignTool
             {
                 application.ShowHelp();
             }
+            application.OnExecute(() =>
+            {
+                application.ShowHelp();
+                return 0;
+            });
             return application.Execute(args);
         }
 


### PR DESCRIPTION
* Convert target framework to netcoreapp2.1
* Add packaging details
* Return E_PLATFORMNOTSUPPORTED if the tool is run on Linux/macOS

I see you already started similar work. Here's how I would have done it.