### PR TITLE
Add roll forward for .NET Core 3

### DIFF
--- a/src/AzureSignTool/runtimeconfig.template.json
+++ b/src/AzureSignTool/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForward": "Major"
+}


### PR DESCRIPTION
This adds the roll forward policy so the `netcoreapp2.1` tool will run on .NET Core 3 if 2.1 isn't available.