### PR TITLE
Implement Azure Identity handling for auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Example usage:
 
     AzureSignTool.exe sign -du "https://vcsjones.com" \
 	  -fd sha384 -kvu https://my-vault.vault.azure.net \
-	  -kvi 01234567-abcd-ef012-0000-0123456789ab \
-	  -kvs <token> \
+	  -kvm \
 	  -kvc my-key-name \
 	  -tr http://timestamp.digicert.com \
 	  -td sha384 \
@@ -26,6 +25,10 @@ The `--help` or `sign --help` option provides more detail about each parameter.
 
 * `--azure-key-vault-url` [short: `-kvu`, required: yes]: A fully qualified URL of the key vault with
 	the certificate that will be used for signing. An example value might be `https://my-vault.vault.azure.net`.
+
+* `--azure-key-vault-managedidentity` [short: `-kvm`, required: possibly]: Set this flag to utilize either your implicit
+	Azure Identity or a Managed Identity.  Set only this flag, or one of `--azure-key-vault-client-id` 
+	`--azure-key-vault-client-accesstoken` parameters
 
 * `--azure-key-vault-client-id` [short: `-kvi`, required: possibly]: This is the client ID used to authenticate to
 	Azure, which will be used to generate an access token. This parameter is not required if an access token is supplied

--- a/src/AzureSign.Core/AzureSign.Core.csproj
+++ b/src/AzureSign.Core/AzureSign.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <Description>Authenticode signing library.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <RuntimeIdentifiers>win10-x64;win-10-x86</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x64;win10-x86</RuntimeIdentifiers>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/AzureSignTool/AzureKeyVaultSignConfigurationSet.cs
+++ b/src/AzureSignTool/AzureKeyVaultSignConfigurationSet.cs
@@ -8,5 +8,6 @@ namespace AzureSignTool
         public string AzureKeyVaultUrl { get; set; }
         public string AzureKeyVaultCertificateName { get; set; }
         public string AzureAccessToken { get; set; }
+        public bool AzureManagedIdentity { get; set; }
     }
 }

--- a/src/AzureSignTool/AzureSignTool.csproj
+++ b/src/AzureSignTool/AzureSignTool.csproj
@@ -11,6 +11,7 @@
   
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />

--- a/src/AzureSignTool/KeyVaultConfigurationDiscoverer.cs
+++ b/src/AzureSignTool/KeyVaultConfigurationDiscoverer.cs
@@ -5,6 +5,7 @@ using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Microsoft.Azure.Services.AppAuthentication;
 
 namespace AzureSignTool
 {
@@ -45,8 +46,12 @@ namespace AzureSignTool
                 }
             }
 
-            var vault = new KeyVaultClient(Authenticate);
-            
+            var callback = configuration.AzureManagedIdentity
+                ? new KeyVaultClient.AuthenticationCallback(new AzureServiceTokenProvider().KeyVaultTokenCallback)
+                : Authenticate;
+
+            var vault = new KeyVaultClient(callback);
+
             X509Certificate2 certificate;
             CertificateBundle azureCertificate;
             try


### PR DESCRIPTION
I updated the Azure Sign Tool to support an Azure Managed Identity.  This allows utilizing the local developer credentials on a machine running the tool.