### PR TITLE
Revert "Add additional logging when KeyVaultError occurs"

### DIFF
--- a/src/AzureSignTool/KeyVaultConfigurationDiscoverer.cs
+++ b/src/AzureSignTool/KeyVaultConfigurationDiscoverer.cs
@@ -47,31 +47,10 @@ namespace AzureSignTool
                 
                 certificate = new X509Certificate2(azureCertificate.Cer);
             }
-            catch (KeyVaultErrorException kvException)
-            {
-                if (authenticationFailure)
-                {
-                    return kvException;
-                }
-
-                _logger.LogError($"Failed to retrieve certificate {configuration.AzureKeyVaultCertificateName} from Azure Key Vault. Please verify the name of the certificate and the permissions to the certificate.");
-
-                var error = kvException.Body.Error;
-                _logger.LogError($"KeyVault Error Code: {error.Code}, Message: {error.Message}");
-
-                if (error.InnerError != null)
-                {
-                    _logger.LogError($"KeyVault Inner Error Code: {error.InnerError.Code}, Message: {error.InnerError.Message}");
-                }
-
-                return kvException;
-            }
             catch (Exception e)
             {
-                if (!authenticationFailure)
-                {
-                    _logger.LogError($"Failed to retrieve certificate {configuration.AzureKeyVaultCertificateName} from Azure Key Vault. Please verify the name of the certificate and the permissions to the certificate. Message: '{e.Message}'");
-                }
+                 _logger.LogError($"Failed to retrieve certificate {configuration.AzureKeyVaultCertificateName} from Azure Key Vault. Please verify the name of the certificate and the permissions to the certificate.");
+                
                 return e;
             }
             var keyId = azureCertificate.KeyId;


### PR DESCRIPTION
Reverts vcsjones/AzureSignTool#85

This broke the build (need to see why CI didn't catch this), looks like the SDK change moved some things around.

cc @SeanKilleen 