### PR TITLE
Show help by default.

### DIFF
--- a/src/AzureSignTool/AzureSignTool.csproj
+++ b/src/AzureSignTool/AzureSignTool.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.2.0-preview.2" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.0.2" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="RSAKeyVaultProvider" Version="2.0.16" />

--- a/src/AzureSignTool/Program.cs
+++ b/src/AzureSignTool/Program.cs
@@ -15,13 +15,19 @@ namespace AzureSignTool
                 Console.Error.WriteLine("Azure Sign Tool is only supported on Windows.");
                 return E_PLATFORMNOTSUPPORTED;
             }
-            var application = new CommandLineApplication<Program>(throwOnUnexpectedArg: false);
+            var application = new CommandLineApplication<Program>();
             application.ValueParsers.Add(new HashAlgorithmNameValueParser());
-            application.Command<SignCommand>("sign", throwOnUnexpectedArg: false, configuration: config =>
+            application.ShowHint();
+            application.Command<SignCommand>("sign", config =>
             {
                 config.Description = "Signs a file.";
                 config.Conventions.UseDefaultConventions();
             });
+            application.Command(string.Empty, config => {
+                application.ShowHelp();
+                application.ShowHint();
+            });
+            application.UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect;
             return application.Execute(args);
         }
     }


### PR DESCRIPTION
If no arguments are specified, show help.

Fix #74 