### PR TITLE
Disable colors by default.

### DIFF
--- a/src/AzureSignTool/AzureSignTool.csproj
+++ b/src/AzureSignTool/AzureSignTool.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Azure.Identity" Version="1.2.0-preview.2" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.0.2" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.4" />
     <PackageReference Include="RSAKeyVaultProvider" Version="2.0.16" />
   </ItemGroup>
   

--- a/src/AzureSignTool/SignCommand.cs
+++ b/src/AzureSignTool/SignCommand.cs
@@ -86,7 +86,8 @@ namespace AzureSignTool
         [Option("-mdop | --max-degree-of-parallelism", "The maximum number of concurrent signing operations.", CommandOptionType.SingleValue), Range(-1, int.MaxValue)]
         public int? MaxDegreeOfParallelism { get; set; }
 
-
+        [Option("--colors", "Enable color output on the command line.", CommandOptionType.NoValue)]
+        public bool Colors { get; set; } = false;
 
         // We manually validate the file's existance with the --input-file-list. Don't validate here.
         [Argument(0, "file", "The path to the file.")]
@@ -187,12 +188,18 @@ namespace AzureSignTool
             return E_INVALIDARG;
         }
 
+        private void ConfigureLogging(ILoggingBuilder builder)
+        {
+            builder.AddConsole(console => {
+                console.DisableColors = !Colors;
+            });
+            builder.SetMinimumLevel(LogLevel);
+        }
+
         public async Task<int> OnExecuteAsync(CommandLineApplication app, IConsole console)
         {
-            using (var loggerFactory = new LoggerFactory())
+            using (var loggerFactory = LoggerFactory.Create(ConfigureLogging))
             {
-
-                loggerFactory.AddConsole(LogLevel, true);
                 var logger = loggerFactory.CreateLogger<SignCommand>();
                 X509Certificate2Collection certificates;
 


### PR DESCRIPTION
The colors seem to sometimes "leak" past the execution of the program.
This might have been fixed by the update to the Extensions.Console
logger, but since it didn't provide a lot of value anyway, disable
them by default, however people can turn them back on anyway.

Off by default makes the most sense since I expect this tool is mostly
used from some kind of automated process.

Fix #73.