### PR TITLE
More details in retrieve cert error message.

### DIFF
--- a/src/AzureSignTool/KeyVaultConfigurationDiscoverer.cs
+++ b/src/AzureSignTool/KeyVaultConfigurationDiscoverer.cs
@@ -49,7 +49,8 @@ namespace AzureSignTool
             }
             catch (Exception e)
             {
-                 _logger.LogError($"Failed to retrieve certificate {configuration.AzureKeyVaultCertificateName} from Azure Key Vault. Please verify the name of the certificate and the permissions to the certificate.");
+                _logger.LogError($"Failed to retrieve certificate {configuration.AzureKeyVaultCertificateName} from Azure Key Vault. Please verify the name of the certificate and the permissions to the certificate. Error message: {e.Message}.");
+                _logger.LogTrace(e.ToString());
                 
                 return e;
             }


### PR DESCRIPTION
Include the error message from the exception when retrieving the certificate fails.

The full stack trace included in the log at trace level - might be too much? If it is, we should at least make sure there is another way to get any inner exception messages at verbose level.

resolves #102 


