### PR TITLE
Log path of file being signed to the console.

### DIFF
--- a/src/AzureSignTool/SignCommand.cs
+++ b/src/AzureSignTool/SignCommand.cs
@@ -191,6 +191,7 @@ namespace AzureSignTool
         private void ConfigureLogging(ILoggingBuilder builder)
         {
             builder.AddConsole(console => {
+                console.IncludeScopes = true;
                 console.DisableColors = !Colors;
             });
             builder.SetMinimumLevel(LogLevel);
@@ -294,11 +295,11 @@ namespace AzureSignTool
                         }
                         using (var loopScope = logger.BeginScope("File: {Id}", filePath))
                         {
-                            logger.LogInformation($"Signing file.");
+                            logger.LogInformation("Signing file.");
 
                             if (SkipSignedFiles && IsSigned(filePath))
                             {
-                                logger.LogInformation($"Skipping already signed file.");
+                                logger.LogInformation("Skipping already signed file.");
                                 return (state.succeeded + 1, state.failed);
                             }
 
@@ -315,7 +316,7 @@ namespace AzureSignTool
 
                             if (result == S_OK)
                             {
-                                logger.LogInformation($"Signing completed successfully.");
+                                logger.LogInformation("Signing completed successfully.");
                                 return (state.succeeded + 1, state.failed);
                             }
                             else


### PR DESCRIPTION
Enable logging of scopes to the console.

The path of the file being signed is included as a logging scope but is currently not being written to the console because IncludeScopes is false.

**Before:**
```
info: AzureSignTool.SignCommand[0]
      Signing file.
info: AzureSignTool.SignCommand[0]
      Signing completed successfully.
info: AzureSignTool.SignCommand[0]
      Successful operations: 1
info: AzureSignTool.SignCommand[0]
      Failed operations: 0
```

**After:**
```
info: AzureSignTool.SignCommand[0]
      => File: D:\signtest\test.exe
      Signing file.
info: AzureSignTool.SignCommand[0]
      => File: D:\signtest\test.exe
      Signing completed successfully.
info: AzureSignTool.SignCommand[0]
      Successful operations: 1
info: AzureSignTool.SignCommand[0]
      Failed operations: 0
```