### PR TITLE
Use SHA256 instead of SHA1 for ChecksumAlgorithm

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,7 @@
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
         <Deterministic>true</Deterministic>
+        <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
     </PropertyGroup>
     
     <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">


### PR DESCRIPTION
`ChecksumAlgorithm` "[controls the checksum algorithm we use to encode source files in the PDB.](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/advanced#checksumalgorithm)"

This change switches from SHA1 (default) to SHA256 for more secure PDB files.