### PR TITLE
Add support for append signature + tests

### DIFF
--- a/src/AzureSign.Core/AuthenticodeKeyVaultSigner.cs
+++ b/src/AzureSign.Core/AuthenticodeKeyVaultSigner.cs
@@ -74,9 +74,10 @@ namespace AzureSign.Core
         /// <param name="description">The description to apply to the signature.</param>
         /// <param name="path">The path to the file to signed.</param>
         /// <param name="logger">An optional logger to capture signing operations.</param>
-        /// <param name="appendSignature">Instruct if should append the new signature to existing, if false - remove existing signatures.</param>
+        /// <param name="appendSignature"><see langword="true"/> if the signature should be appended to an existing signature. When <see langword="false"/>, any existing signatures will be replaced.</param>
         /// <returns>A HRESULT indicating the result of the signing operation. S_OK, or zero, is returned if the signing
         /// operation completed successfully.</returns>
+        <exception cref="PlatformNotSupportedException"><paramref name="appendSignature"/> was set to <see langword="true"/> however the current operating system does not support appending signatures.</exception>
         public unsafe int SignFile(ReadOnlySpan<char> path, ReadOnlySpan<char> description, ReadOnlySpan<char> descriptionUrl, bool? pageHashing, ILogger? logger = null, bool appendSignature = false)
         {
             static char[] NullTerminate(ReadOnlySpan<char> str)

--- a/src/AzureSign.Core/AuthenticodeKeyVaultSigner.cs
+++ b/src/AzureSign.Core/AuthenticodeKeyVaultSigner.cs
@@ -1,4 +1,4 @@
-﻿using AzureSign.Core.Interop;
+using AzureSign.Core.Interop;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Diagnostics;
@@ -73,9 +73,10 @@ namespace AzureSign.Core
         /// <param name="description">The description to apply to the signature.</param>
         /// <param name="path">The path to the file to signed.</param>
         /// <param name="logger">An optional logger to capture signing operations.</param>
+        /// <param name="appendSignature">Instruct if should append the new signature to existing, if false - remove existing signatures.</param>
         /// <returns>A HRESULT indicating the result of the signing operation. S_OK, or zero, is returned if the signing
         /// operation completed successfully.</returns>
-        public unsafe int SignFile(ReadOnlySpan<char> path, ReadOnlySpan<char> description, ReadOnlySpan<char> descriptionUrl, bool? pageHashing, ILogger? logger = null)
+        public unsafe int SignFile(ReadOnlySpan<char> path, ReadOnlySpan<char> description, ReadOnlySpan<char> descriptionUrl, bool? pageHashing, ILogger? logger = null, bool appendSignature = false)
         {
             static char[] NullTerminate(ReadOnlySpan<char> str)
             {
@@ -94,6 +95,11 @@ namespace AzureSign.Core
             else if (pageHashing == false)
             {
                 flags |= SignerSignEx3Flags.SPC_EXC_PE_PAGE_HASHES_FLAG;
+            }
+
+            if (appendSignature)
+            {
+                flags |= SignerSignEx3Flags.SIG_APPEND;
             }
 
             SignerSignTimeStampFlags timeStampFlags;

--- a/src/AzureSign.Core/AuthenticodeKeyVaultSigner.cs
+++ b/src/AzureSign.Core/AuthenticodeKeyVaultSigner.cs
@@ -20,6 +20,7 @@ namespace AzureSign.Core
         private readonly MemoryCertificateStore _certificateStore;
         private readonly X509Chain _chain;
         private readonly SignCallback _signCallback;
+        private static readonly Version _win11Version = new Version(10, 0, 22000);
 
 
         /// <summary>
@@ -99,9 +100,7 @@ namespace AzureSign.Core
 
             if (appendSignature)
             {
-                // OperatingSystem.IsWindowsVersionAtLeast is not yet introduced in .Net Standard 2.0
-                bool isWindows11OrGreater = Environment.OSVersion.Version.Major >= 10 && Environment.OSVersion.Version.Minor >= 0 && Environment.OSVersion.Version.Build >= 22000;
-                if (!isWindows11OrGreater)
+                if (Environment.OSVersion.Version < _win11Version)
                 {
                     // must throw, if continued SignerSignEx3 might return no error, but fail with the task, we must prevent this silent corruption.
                     throw new PlatformNotSupportedException("Appending signatures requires Windows 11 or later.");

--- a/src/AzureSign.Core/AuthenticodeKeyVaultSigner.cs
+++ b/src/AzureSign.Core/AuthenticodeKeyVaultSigner.cs
@@ -77,7 +77,7 @@ namespace AzureSign.Core
         /// <param name="appendSignature"><see langword="true"/> if the signature should be appended to an existing signature. When <see langword="false"/>, any existing signatures will be replaced.</param>
         /// <returns>A HRESULT indicating the result of the signing operation. S_OK, or zero, is returned if the signing
         /// operation completed successfully.</returns>
-        <exception cref="PlatformNotSupportedException"><paramref name="appendSignature"/> was set to <see langword="true"/> however the current operating system does not support appending signatures.</exception>
+        /// <exception cref="PlatformNotSupportedException"><paramref name="appendSignature"/> was set to <see langword="true"/> however the current operating system does not support appending signatures.</exception>
         public unsafe int SignFile(ReadOnlySpan<char> path, ReadOnlySpan<char> description, ReadOnlySpan<char> descriptionUrl, bool? pageHashing, ILogger? logger = null, bool appendSignature = false)
         {
             static char[] NullTerminate(ReadOnlySpan<char> str)

--- a/src/AzureSignTool/SignCommand.cs
+++ b/src/AzureSignTool/SignCommand.cs
@@ -1,4 +1,4 @@
-﻿using AzureSign.Core;
+using AzureSign.Core;
 using McMaster.Extensions.CommandLineUtils;
 using McMaster.Extensions.CommandLineUtils.Abstractions;
 using Microsoft.Extensions.Logging;
@@ -91,6 +91,9 @@ namespace AzureSignTool
 
         [Option("-s | --skip-signed", "Skip files that are already signed.", CommandOptionType.NoValue)]
         public bool SkipSignedFiles { get; set; } = false;
+
+        [Option("-as | --append-signature", "Append the signature, has no effect with --skip-signed.", CommandOptionType.NoValue)]
+        public bool AppendSignature { get; set; } = false;
 
         // We manually validate the file's existance with the --input-file-list. Don't validate here.
         [Argument(0, "file", "The path to the file.")]
@@ -254,6 +257,7 @@ namespace AzureSignTool
                 {
                     performPageHashing = false;
                 }
+                bool appendSignature = AppendSignature;
                 var configurationDiscoverer = new KeyVaultConfigurationDiscoverer(logger);
                 var materializedResult = await configurationDiscoverer.Materialize(configuration);
                 AzureKeyVaultMaterializedConfiguration materialized;
@@ -304,7 +308,7 @@ namespace AzureSignTool
                                 return (state.succeeded + 1, state.failed);
                             }
 
-                            var result = signer.SignFile(filePath, Description, DescriptionUri, performPageHashing, logger);
+                            var result = signer.SignFile(filePath, Description, DescriptionUri, performPageHashing, logger, appendSignature);
                             switch (result)
                             {
                                 case COR_E_BADIMAGEFORMAT:

--- a/src/AzureSignTool/SignCommand.cs
+++ b/src/AzureSignTool/SignCommand.cs
@@ -1,4 +1,4 @@
-using AzureSign.Core;
+﻿using AzureSign.Core;
 using McMaster.Extensions.CommandLineUtils;
 using McMaster.Extensions.CommandLineUtils.Abstractions;
 using Microsoft.Extensions.Logging;
@@ -172,7 +172,16 @@ namespace AzureSignTool
             {
                 return new ValidationResult("At least one file must be specified to sign.");
             }
-            foreach(var file in AllFiles)
+            if (AppendSignature && !OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
+            {
+                return new ValidationResult("'--append-signature' requires Windows 11 or later.", new[] { nameof(AppendSignature) });
+            }
+            if (AppendSignature && AuthenticodeTimestamp.Present)
+            {
+                return new ValidationResult("Cannot use '--append-signature' and '--timestamp-authenticode' options together.", new[] { nameof(AppendSignature), nameof(AuthenticodeTimestamp) });
+            }
+
+            foreach (var file in AllFiles)
             {
                 if (!File.Exists(file))
                 {

--- a/test/AzureSign.Core.Tests/AuthenticodeKeyVaultSignerTests.cs
+++ b/test/AzureSign.Core.Tests/AuthenticodeKeyVaultSignerTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
@@ -27,10 +27,13 @@ namespace AzureSign.Core.Tests
             var fileToSign = GetFileToSign();
             var result = signer.SignFile(fileToSign, null, null, null);
             Assert.Equal(0, result);
-            result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
-            Assert.Equal(0, result);
-            result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
-            Assert.Equal(0, result);
+            if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
+            {
+                result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
+                Assert.Equal(0, result);
+                result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
+                Assert.Equal(0, result);
+            }
         }
 
         [Theory]
@@ -42,10 +45,13 @@ namespace AzureSign.Core.Tests
             var fileToSign = GetFileToSign();
             var result = signer.SignFile(fileToSign, null, null, null);
             Assert.Equal(0, result);
-            result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
-            Assert.Equal(0, result);
-            result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
-            Assert.Equal(0, result);
+            if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
+            {
+                result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
+                Assert.Equal(0, result);
+                result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
+                Assert.Equal(0, result);
+            }
         }
 
 
@@ -58,10 +64,13 @@ namespace AzureSign.Core.Tests
             var fileToSign = GetFileToSign();
             var result = signer.SignFile(fileToSign, null, null, null);
             Assert.Equal(0, result);
-            result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
-            Assert.Equal(0, result);
-            result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
-            Assert.Equal(0, result);
+            if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
+            {
+                result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
+                Assert.Equal(0, result);
+                result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
+                Assert.Equal(0, result);
+            }
         }
 
         [Theory]
@@ -74,10 +83,13 @@ namespace AzureSign.Core.Tests
             var fileToSign = GetFileToSign();
             var result = signer.SignFile(fileToSign, null, null, null);
             Assert.Equal(0, result);
-            result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
-            Assert.Equal(0, result);
-            result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
-            Assert.Equal(0, result);
+            if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
+            {
+                result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
+                Assert.Equal(0, result);
+                result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
+                Assert.Equal(0, result);
+            }
         }
 
 
@@ -91,10 +103,13 @@ namespace AzureSign.Core.Tests
             var fileToSign = GetFileToSign();
             var result = signer.SignFile(fileToSign, null, null, null);
             Assert.Equal(0, result);
-            result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
-            Assert.Equal(0, result);
-            result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
-            Assert.Equal(0, result);
+            if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
+            {
+                result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
+                Assert.Equal(0, result);
+                result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
+                Assert.Equal(0, result);
+            }
         }
 
         private string GetFileToSign()

--- a/test/AzureSign.Core.Tests/AuthenticodeKeyVaultSignerTests.cs
+++ b/test/AzureSign.Core.Tests/AuthenticodeKeyVaultSignerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
@@ -27,6 +27,10 @@ namespace AzureSign.Core.Tests
             var fileToSign = GetFileToSign();
             var result = signer.SignFile(fileToSign, null, null, null);
             Assert.Equal(0, result);
+            result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
+            Assert.Equal(0, result);
+            result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
+            Assert.Equal(0, result);
         }
 
         [Theory]
@@ -37,6 +41,10 @@ namespace AzureSign.Core.Tests
             var signer = new AuthenticodeKeyVaultSigner(signingCert.GetRSAPrivateKey(), signingCert, HashAlgorithmName.SHA256, TimeStampConfiguration.None);
             var fileToSign = GetFileToSign();
             var result = signer.SignFile(fileToSign, null, null, null);
+            Assert.Equal(0, result);
+            result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
+            Assert.Equal(0, result);
+            result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
             Assert.Equal(0, result);
         }
 
@@ -50,6 +58,10 @@ namespace AzureSign.Core.Tests
             var fileToSign = GetFileToSign();
             var result = signer.SignFile(fileToSign, null, null, null);
             Assert.Equal(0, result);
+            result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
+            Assert.Equal(0, result);
+            result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
+            Assert.Equal(0, result);
         }
 
         [Theory]
@@ -61,6 +73,10 @@ namespace AzureSign.Core.Tests
             var signer = new AuthenticodeKeyVaultSigner(signingCert.GetECDsaPrivateKey(), signingCert, HashAlgorithmName.SHA256, timestampConfig);
             var fileToSign = GetFileToSign();
             var result = signer.SignFile(fileToSign, null, null, null);
+            Assert.Equal(0, result);
+            result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
+            Assert.Equal(0, result);
+            result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
             Assert.Equal(0, result);
         }
 
@@ -74,6 +90,10 @@ namespace AzureSign.Core.Tests
             var signer = new AuthenticodeKeyVaultSigner(signingCert.GetRSAPrivateKey(), signingCert, HashAlgorithmName.SHA256, timestampConfig);
             var fileToSign = GetFileToSign();
             var result = signer.SignFile(fileToSign, null, null, null);
+            Assert.Equal(0, result);
+            result = signer.SignFile(fileToSign, null, null, null, appendSignature: true);
+            Assert.Equal(0, result);
+            result = signer.SignFile(fileToSign, null, null, null, appendSignature: false);
             Assert.Equal(0, result);
         }
 


### PR DESCRIPTION
Expose the existing Win API option to add a signature instead of overriding through the new optional command line argument: **-as** or **--append-signature**