### PR TITLE
Add support for other Azure clouds in CLI

### DIFF
--- a/src/AzureSignTool/AuthorityHostNames.cs
+++ b/src/AzureSignTool/AuthorityHostNames.cs
@@ -1,0 +1,30 @@
+#nullable enable
+using Azure.Identity;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace AzureSignTool
+{
+    internal static class AuthorityHostNames
+    {
+        private static readonly ImmutableDictionary<string, Uri> _map = ImmutableDictionary.CreateRange(
+            StringComparer.OrdinalIgnoreCase,
+            [
+                KeyValuePair.Create("gov", AzureAuthorityHosts.AzureGovernment),
+                KeyValuePair.Create("germany", AzureAuthorityHosts.AzureGermany),
+                KeyValuePair.Create("china", AzureAuthorityHosts.AzureChina),
+                KeyValuePair.Create("public", AzureAuthorityHosts.AzurePublicCloud),
+            ]);
+
+        public static Uri? GetUriForAzureAuthorityIdentifier(string identifier)
+        {
+            if (_map.TryGetValue(identifier, out Uri? host))
+            {
+                return host;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/AzureSignTool/AzureKeyVaultSignConfigurationSet.cs
+++ b/src/AzureSignTool/AzureKeyVaultSignConfigurationSet.cs
@@ -11,5 +11,6 @@ namespace AzureSignTool
         public Uri AzureKeyVaultUrl { get; init; }
         public string AzureKeyVaultCertificateName { get; init; }
         public string AzureAccessToken { get; init; }
+        public string AzureAuthority { get; init; }
     }
 }

--- a/src/AzureSignTool/KeyVaultConfigurationDiscoverer.cs
+++ b/src/AzureSignTool/KeyVaultConfigurationDiscoverer.cs
@@ -31,7 +31,18 @@ namespace AzureSignTool
             }
             else
             {
-                credential = new ClientSecretCredential(configuration.AzureTenantId, configuration.AzureClientId, configuration.AzureClientSecret);
+                if (string.IsNullOrWhiteSpace(configuration.AzureAuthority))
+                {
+                    credential = new ClientSecretCredential(configuration.AzureTenantId, configuration.AzureClientId, configuration.AzureClientSecret);
+                }
+                else
+                {
+                    ClientSecretCredentialOptions options = new()
+                    {
+                        AuthorityHost = AuthorityHostNames.GetUriForAzureAuthorityIdentifier(configuration.AzureAuthority)
+                    };
+                    credential = new ClientSecretCredential(configuration.AzureTenantId, configuration.AzureClientId, configuration.AzureClientSecret, options);
+                }
             }
 
 

--- a/src/AzureSignTool/SignCommand.cs
+++ b/src/AzureSignTool/SignCommand.cs
@@ -96,6 +96,10 @@ namespace AzureSignTool
         [Option("-as | --append-signature", "Append the signature, has no effect with --skip-signed.", CommandOptionType.NoValue)]
         public bool AppendSignature { get; set; } = false;
 
+        [Option("-au | --azure-authority", "The Azure Authority for Azure Key Vault.", CommandOptionType.SingleValue)]
+        [AllowedValues("china", "germany", "gov", "public", IgnoreCase = true)]
+        public string AzureAuthority { get; set; }
+
         // We manually validate the file's existance with the --input-file-list. Don't validate here.
         [Argument(0, "file", "The path to the file.")]
         public string[] Files { get; set; } = [];
@@ -240,6 +244,7 @@ namespace AzureSignTool
                     AzureAccessToken = KeyVaultAccessToken.Value,
                     AzureClientSecret = KeyVaultClientSecret.Value,
                     ManagedIdentity = UseManagedIdentity,
+                    AzureAuthority = AzureAuthority,
                 };
 
                 TimeStampConfiguration timeStampConfiguration;


### PR DESCRIPTION
This adds an optional CLI argument, `-au` or `--azure-authority` that allows specifying other Azure clouds, like Gov, Germany, etc.

If not specified, the existing behavior will remain, including the `AZURE_AUTHORITY_HOST` environment variable will continue to work.

Closes #161
Closes #158 