### PR TITLE
Add --version

### DIFF
--- a/src/AzureSignTool/Program.cs
+++ b/src/AzureSignTool/Program.cs
@@ -21,6 +21,7 @@ namespace AzureSignTool
             {
                 config.Description = "Signs a file.";
             });
+            application.VersionOptionFromAssemblyAttributes(typeof(Program).Assembly);
             application.Conventions.UseDefaultConventions();
             application.UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.StopParsingAndCollect;
             return application.Execute(args);

--- a/test/AzureSignTool.Tests/HelpTests.cs
+++ b/test/AzureSignTool.Tests/HelpTests.cs
@@ -30,6 +30,30 @@ namespace AzureSignTool.Tests
             Assert.NotEqual(0, ExitCode);
         }
 
+        [Fact]
+        public void ShowVersionOnOutputForHelp()
+        {
+            (string StdOut, string StdErr, int ExitCode) = Capture(() => {
+                return Program.Main([]);
+            });
+
+            Assert.Matches(@"^\d\.\d\.\d", StdOut);
+            Assert.NotEqual(0, ExitCode);
+        }
+
+        [Fact]
+        public void ShowVersionOnOutputVersionArg()
+        {
+            (string StdOut, string StdErr, int ExitCode) = Capture(() => {
+                return Program.Main(["--version"]);
+            });
+
+            // This is from https://semver.org/
+            const string SemVerRegex = @"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$";
+            Assert.Matches(SemVerRegex, StdOut);
+            Assert.Equal(0, ExitCode);
+        }
+
         private static (string StdOut, string StdErr, T Result) Capture<T>(Func<T> act)
         {
             lock (_sync)

--- a/test/AzureSignTool.Tests/HelpTests.cs
+++ b/test/AzureSignTool.Tests/HelpTests.cs
@@ -48,9 +48,7 @@ namespace AzureSignTool.Tests
                 return Program.Main(["--version"]);
             });
 
-            // This is from https://semver.org/
-            const string SemVerRegex = @"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$";
-            Assert.Matches(SemVerRegex, StdOut);
+            Assert.Matches(@"^\d\.\d\.\d", StdOut);
             Assert.Equal(0, ExitCode);
         }
 


### PR DESCRIPTION
This adds the version in two places.

1. Just running AzureSignTool with zero options will show the version, in addition to the command help.
2. Introduces a new `--version` output that prints the semver version of AzureSignTool without the help. This may be useful for other tooling that want to parse AzureSignTool's version.

Fix #171 