### PR TITLE
Fix validation error in SignCommand.cs

### DIFF
--- a/src/AzureSignTool/SignCommand.cs
+++ b/src/AzureSignTool/SignCommand.cs
@@ -148,7 +148,7 @@ namespace AzureSignTool
             }
             if (Quiet && Verbose)
             {
-                return new ValidationResult("Cannot use '--quiet' and '--verbose' options together.", new[] { nameof(NoPageHashing), nameof(PageHashing) });
+                return new ValidationResult("Cannot use '--quiet' and '--verbose' options together.", new[] { nameof(Quiet), nameof(Verbose) });
             }
             if (!OneTrue(KeyVaultAccessToken.Present, KeyVaultClientId.Present, UseManagedIdentity))
             {


### PR DESCRIPTION
This is a copy/paste error.

The commit fixes a validation error in the `SignCommand.cs` file. The code now correctly checks for the use of '--quiet' and '--verbose' options together, returning an appropriate validation result.