### PR TITLE
fix: handle azure keyvault throttling with retry logic

### DIFF
--- a/src/AzureSignTool/AzureSignTool.csproj
+++ b/src/AzureSignTool/AzureSignTool.csproj
@@ -22,6 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="RSAKeyVaultProvider" Version="2.1.1" />
+    <PackageReference Include="Polly" Version="8.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AzureSignTool/HRESULT.cs
+++ b/src/AzureSignTool/HRESULT.cs
@@ -12,5 +12,7 @@
         public const int E_ALL_FAILED = unchecked((int)0xA0000002);
 
         public const int TRUST_E_SUBJECT_FORM_UNKNOWN = unchecked((int)0x800B0003);
+
+        public const int E_VAULT_THROTTLING = unchecked((int)0x801901AD);
     }
 }


### PR DESCRIPTION
Include retry logic to deal with Azure KeyVault throttling errors that may occur during large sign batches, as described in Microsoft docs:
https://learn.microsoft.com/en-us/azure/key-vault/general/overview-throttling
