### PR TITLE
File system globbing support

### DIFF
--- a/src/AzureSignTool/AzureSignTool.csproj
+++ b/src/AzureSignTool/AzureSignTool.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Azure.Identity" Version="1.11.2" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
     <PackageReference Include="XenoAtom.CommandLine" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />

--- a/src/AzureSignTool/Program.cs
+++ b/src/AzureSignTool/Program.cs
@@ -127,6 +127,8 @@ namespace AzureSignTool
 
                 static void Add(HashSet<string> collection, Matcher matcher, string item)
                 {
+                    // We require explicit glob pattern wildcards in order to treat it as a glob. e.g.
+                    // dir/ will not be treated as a directory. It must be explicitly dir/*.exe or dir/**/*.exe, for example.
                     if (item.Contains('*'))
                     {
                         matcher.AddInclude(item);

--- a/src/AzureSignTool/Program.cs
+++ b/src/AzureSignTool/Program.cs
@@ -8,6 +8,8 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using AzureSign.Core;
+using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using RSAKeyVaultProvider;
@@ -89,7 +91,14 @@ namespace AzureSignTool
             {
                 if (_allFiles is null)
                 {
-                    _allFiles = new HashSet<string>(Files);
+                    _allFiles = [];
+                    Matcher matcher = new();
+
+                    foreach (string file in Files)
+                    {
+                        Add(_allFiles, matcher, file);
+                    }
+
                     if (!string.IsNullOrWhiteSpace(InputFileList))
                     {
                         foreach(string line in File.ReadLines(InputFileList))
@@ -99,11 +108,34 @@ namespace AzureSignTool
                                 continue;
                             }
 
-                            _allFiles.Add(line);
+                            Add(_allFiles, matcher, line);
+                        }
+                    }
+
+                    PatternMatchingResult results = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(".")));
+
+                    if (results.HasMatches)
+                    {
+                        foreach (var result in results.Files)
+                        {
+                            _allFiles.Add(result.Path);
                         }
                     }
                 }
+
                 return _allFiles;
+
+                static void Add(HashSet<string> collection, Matcher matcher, string item)
+                {
+                    if (item.Contains('*'))
+                    {
+                        matcher.AddInclude(item);
+                    }
+                    else
+                    {
+                        collection.Add(item);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
If an input on the CLI or in the input-file-list contains a wildcard character, treat it as a glob. For example, this will now work:

```shell
azuresigntool ... C:\files\*.exe # glob by extension
azuresigntool ... C:\files\**\*.exe # glob including subdirectories
```

This implementation explicitly requires the use of an asterisk for globbing. "C:\files\" will not be treated as as sign everything in that directory. It must have a pattern like "C:\files\**\*" to sign everything under a directory.

Fixes #206