### PR TITLE
Use Azure SDK for RSA algorithm

### DIFF
--- a/src/AzureSignTool/AzureSignTool.csproj
+++ b/src/AzureSignTool/AzureSignTool.csproj
@@ -27,7 +27,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="RSAKeyVaultProvider" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AzureSignTool/Program.cs
+++ b/src/AzureSignTool/Program.cs
@@ -7,12 +7,12 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Security.KeyVault.Keys.Cryptography;
 using AzureSign.Core;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
-using RSAKeyVaultProvider;
 using XenoAtom.CommandLine;
 
 using static AzureSignTool.HRESULT;
@@ -272,7 +272,8 @@ namespace AzureSignTool
                 }
                 logger.LogTrace("Creating context");
 
-                using (var keyVault = RSAFactory.Create(materialized.TokenCredential, materialized.KeyId, materialized.PublicCertificate))
+                var client = new CryptographyClient(materialized.KeyId, materialized.TokenCredential);
+                using (var keyVault = client.CreateRSA())
                 using (var signer = new AuthenticodeKeyVaultSigner(keyVault, materialized.PublicCertificate, ParseHashAlgorithm(FileDigestAlgorithm), timeStampConfiguration, certificates))
                 {
                     Parallel.ForEach(AllFiles, options, () => (succeeded: 0, failed: 0), (filePath, pls, state) =>


### PR DESCRIPTION
This removes the dependency on RSAKeyVaultProvider and uses the functionality provided in the Azure SDK out of the box.

Using the Azure SDK directly lets us specify a retry policy with `CryptographyClientOptions`.