### PR TITLE
Add the correct description

### DIFF
--- a/src/AzureSignTool/Program.cs
+++ b/src/AzureSignTool/Program.cs
@@ -317,7 +317,7 @@ namespace AzureSignTool
                                 return (state.succeeded + 1, state.failed);
                             }
 
-                            var result = signer.SignFile(filePath, Description, SignDescriptionUrl, performPageHashing, logger, appendSignature);
+                            var result = signer.SignFile(filePath, null, SignDescriptionUrl, performPageHashing, logger, appendSignature);
                             switch (result)
                             {
                                 case COR_E_BADIMAGEFORMAT:

--- a/src/AzureSignTool/Program.cs
+++ b/src/AzureSignTool/Program.cs
@@ -317,7 +317,7 @@ namespace AzureSignTool
                                 return (state.succeeded + 1, state.failed);
                             }
 
-                            var result = signer.SignFile(filePath, null, SignDescriptionUrl, performPageHashing, logger, appendSignature);
+                            var result = signer.SignFile(filePath, SignDescription, SignDescriptionUrl, performPageHashing, logger, appendSignature);
                             switch (result)
                             {
                                 case COR_E_BADIMAGEFORMAT:


### PR DESCRIPTION
fixes #257

This code was adding the AzureSignTool Command.Description to the signed file. Sending null allows the codesigning to reuse the existing description.