### PR TITLE
Re-enable 32bit publishing for office VBA

### DIFF
--- a/src/AzureSign.Core/AzureSign.Core.csproj
+++ b/src/AzureSign.Core/AzureSign.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Description>Authenticode signing library.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-arm64;win-x86</RuntimeIdentifiers>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <Nullable>enable</Nullable>

--- a/src/AzureSignTool/AzureSignTool.csproj
+++ b/src/AzureSignTool/AzureSignTool.csproj
@@ -6,10 +6,10 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>azuresigntool</ToolCommandName>
     <Description>Azure Sign Tool is similar to signtool in the Windows SDK, with the major difference being that it uses Azure Key Vault for performing the signing process. The usage is like signtool, except with a limited set of options for signing and options for authenticating to Azure Key Vault.</Description>
-    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-arm64;win-x86</RuntimeIdentifiers>
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PublishAot>true</PublishAot>
+    <PublishAot Condition="$(RuntimeIdentifier.EndsWith('64'))">true</PublishAot>
     <EventSourceSupport>false</EventSourceSupport>
     <HttpActivityPropagationSupport>false</HttpActivityPropagationSupport>
     <OptimizationPreference>Size</OptimizationPreference>


### PR DESCRIPTION
### Disabling 32bit breaks Office-VBA signing
Keeping 32-bit support in place is crucial, while at the same time enable new 64-bit related features.

1. Re-enable 32bit Windows publishing needed for signing Office macros (OfficeSIPs needed for signing VBA in office files are only available as 32bit). 

1. PublishAOT still available for 64-bit Windows publishing via build-condition.

This helps fixing problems as described in #126 