### PR TITLE
doc: add more context about DefaultAzureCredential Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The single-file downloads do not require .NET to be installed on the system at a
 	Azure.
 
 * `--azure-key-vault-managed-identity` [short: `-kvm`, required: possibly]: Use the ambiant Managed Identity to authenticate to Azure. This
-	can be used instead of the `--azure-key-vault-accesstoken`, `--azure-key-vault-client-id` and `--azure-key-vault-client-secret` options. Important to mention that this option uses a combination of authentication mechanisms listed under [DefaultAzureCredential Class](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet#definition). Beside Managed Identity, this also allows you to use existing sessions in the Azure CLI or PowerShell. It also supports Visual Studio Credentials, Interactive Browser Authentication and more.
+	can be used instead of the `--azure-key-vault-accesstoken`, `--azure-key-vault-client-id` and `--azure-key-vault-client-secret` options. This option uses a combination of authentication mechanisms listed under [DefaultAzureCredential Class](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet#definition). Beside Managed Identity, this also allows you to use existing sessions in the Azure CLI or PowerShell. It also supports Visual Studio Credentials, Interactive Browser Authentication and others.
 
 * `--description` [short: `-d`, required: no]: A description of the signed content. This parameter serves the same purpose
 	as the `/d` option in the Windows SDK `signtool`. If this parameter is not supplied, the signature will not contain a

--- a/README.md
+++ b/README.md
@@ -96,9 +96,7 @@ The single-file downloads do not require .NET to be installed on the system at a
 	Azure.
 
 * `--azure-key-vault-managed-identity` [short: `-kvm`, required: possibly]: Use the ambiant Managed Identity to authenticate to Azure. This
-	can be used instead of the `--azure-key-vault-accesstoken`, `--azure-key-vault-client-id` and `--azure-key-vault-client-secret` options. This is useful
-	if AzureSignTool is being used on a VM/service/CLI that is configured for managed identities to
-	Azure. Important to mention is that this option leverages the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet) class which is trying to get a token via multiple options including Visual Studio Credentials and Interactive Browser Authentication.
+	can be used instead of the `--azure-key-vault-accesstoken`, `--azure-key-vault-client-id` and `--azure-key-vault-client-secret` options. Important to mention that this option uses a combination of authentication mechanisms listed under [DefaultAzureCredential Class](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet#definition). Beside Managed Identity, this also allows you to use existing sessions in the Azure CLI or PowerShell. It also supports Visual Studio Credentials, Interactive Browser Authentication and more.
 
 * `--description` [short: `-d`, required: no]: A description of the signed content. This parameter serves the same purpose
 	as the `/d` option in the Windows SDK `signtool`. If this parameter is not supplied, the signature will not contain a


### PR DESCRIPTION
The DefaultAzureCredential Class is powerful. It tries different authentication methods and allow also the use of existing authentications like in an Azure CLI. See #286 for an example of using modern authentication via JWT-Tokens with the DefaultAzureCredential Class.