### PR TITLE
Add OS version check

### DIFF
--- a/src/AzureSignTool/Program.cs
+++ b/src/AzureSignTool/Program.cs
@@ -30,6 +30,12 @@ namespace AzureSignTool
                 return Task.FromResult(E_PLATFORMNOTSUPPORTED);
             }
 
+            if (!OperatingSystem.IsWindowsVersionAtLeast(10))
+            {
+                Console.Error.WriteLine("Azure Sign Tool requires Windows 10 or later.");
+                return Task.FromResult(E_PLATFORMNOTSUPPORTED);
+            }
+
             var app = new CommandApp("azuresigntool")
             {
                 new VersionOption(version: GetVersion(), prototype: "version"),


### PR DESCRIPTION
If AzureSignTool is run on a version of Windows older than 10, it will fail saying `SignerSignEx3` can't be found. This gives a friendlier error message.

Closes #294 