### PR TITLE
Skip CI on markdown-only changes.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build:


### PR DESCRIPTION
Let's see if CI will block merge with an ignore.